### PR TITLE
Added parameter to list all available versions

### DIFF
--- a/build
+++ b/build
@@ -38,19 +38,30 @@ get_latest_version_number_from_dockerhub() {
   echo "$latest"
 }
 
+get_available_version_numbers_from_dockerhub() {
+  local image_name="$1"
+
+  versions="$(curl https://hub.docker.com/v2/repositories/"$image_name"/tags 2>/dev/null | jq -r '.results[].name' | grep "\-ce")"
+  
+  echo "$versions"
+}
+
 help()
 {
    # Display Help
    echo "Syntax: build <version> [options]"
    echo "arguments:"
-   echo "  version - GitLab CE version e.g. 13.4.3-ce.0"
+   echo "  version         - GitLab CE version e.g. 13.4.3-ce.0"
+   echo "                    Use '--list-versions' to get a list of available versions"
    echo "options:"
-   echo "  --type  - package type (classic|advanced) - default: classic"
-   echo "  --dsm   - target DSM version (6|7) - default: 7"
+   echo "  --type          - package type (classic|advanced) - default: classic"
+   echo "  --dsm           - target DSM version (6|7) - default: 7"
+   echo "  --list-versions - List all available versions"
    echo
    echo "Example: build 13.4.3-ce.0 --dsm=7 --type=classic"
    exit 0
 }
+
 
 ###########################################################
 # DEFAULT VARIABLES
@@ -75,6 +86,15 @@ do
       ;;
       --dsm=*)
           GITLAB_DSM_VERSION="${i#*=}"
+      ;;
+      --list-versions)
+         echo "Available versions:"
+         GITLAB_AVAILABLE_VERSIONS="$(get_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME")"
+         while IFS= read -r line; do
+             echo "  - $line"
+         done <<< "$GITLAB_AVAILABLE_VERSIONS"
+
+         exit 0
       ;;
       -h|--help)
           help

--- a/build
+++ b/build
@@ -38,10 +38,18 @@ get_latest_version_number_from_dockerhub() {
   echo "$latest"
 }
 
-show_available_version_numbers_from_dockerhub() {
+get_available_version_numbers_from_dockerhub() {
   local image_name="$1"
 
   versions="$(curl https://hub.docker.com/v2/repositories/"$image_name"/tags 2>/dev/null | jq -r '.results[].name' | grep "\-ce")"
+  
+  echo "$versions"
+}
+
+show_available_version_numbers_from_dockerhub() {
+  local image_name="$1"
+
+  versions=$(get_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME")
   
   echo "Available versions:"
   while IFS= read -r line; do
@@ -54,9 +62,8 @@ help()
    # Display Help
    echo "Syntax: build <version> [options]"
    echo "arguments:"
-   echo "  version         - GitLab CE version e.g. 13.4.3-ce.0"
+   echo "  --version       - GitLab CE version e.g. 13.4.3-ce.0"
    echo "                    Use '--list-versions' to get a list of available versions"
-   echo "options:"
    echo "  --type          - package type (classic|advanced) - default: classic"
    echo "  --dsm           - target DSM version (6|7) - default: 7"
    echo "  --list-versions - List all available versions"
@@ -70,7 +77,7 @@ help()
 # DEFAULT VARIABLES
 ###########################################################
 GITLAB_PACKAGE_TYPE="classic"
-GITLAB_DSM_VERSION="7"
+DSM_VERSION="7"
 GITLAB_IMAGE_NAME="gitlab/gitlab-ce"
 GITLAB_IMAGE_VERSION="13.4.3-ce.0"
 
@@ -81,14 +88,18 @@ DIRECTORY_TMP="./tmp"
 # PARAMETER HANDLING
 ###########################################################
 PARAMS=""
+GITLAB_IMAGE_VERSION=""
 for i in "$@"
 do
     case ${i} in
+      --version=*)
+          GITLAB_IMAGE_VERSION="${i#*=}"
+      ;;
       --type=*)
           GITLAB_PACKAGE_TYPE="${i#*=}"
       ;;
       --dsm=*)
-          GITLAB_DSM_VERSION="${i#*=}"
+          DSM_VERSION="${i#*=}"
       ;;
       --list-versions)
          show_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME"
@@ -105,37 +116,38 @@ do
 done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
-
 if [ "$GITLAB_PACKAGE_TYPE" != "classic" ] && [ "$GITLAB_PACKAGE_TYPE" != "advanced" ]; then
-  echo "GITLAB_PACKAGE_TYPE $GITLAB_PACKAGE_TYPE is unknown, only classic|advanced allowed."
+  echo "type $GITLAB_PACKAGE_TYPE is unknown, only classic|advanced allowed!"
   exit 1
 fi
 
-if [ "$GITLAB_DSM_VERSION" != "6" ] && [ "$GITLAB_DSM_VERSION" != "7" ]; then
-  echo "GITLAB_DSM_VERSION $GITLAB_DSM_VERSION is unknown, only 6|7 allowed."
+# Validate DSM version
+if [ "$DSM_VERSION" != "6" ] && [ "$DSM_VERSION" != "7" ]; then
+  echo "DSM version $DSM_VERSION is unknown, only 6|7 allowed!"
   exit 1
 fi
 
 # validate version
-if [ -z "$1" ]; then
-  GITLAB_VERSION_LATEST="$(get_latest_version_number_from_dockerhub "$GITLAB_IMAGE_NAME")"
-  read -ep "gitlab version [default (latest): $GITLAB_VERSION_LATEST]: " GITLAB_IMAGE_VERSION
-  if [ -z "$GITLAB_IMAGE_VERSION" ]; then
-    GITLAB_IMAGE_VERSION="$GITLAB_VERSION_LATEST"
-  fi
-else
-  GITLAB_IMAGE_VERSION="$1"
+if [[ "$GITLAB_IMAGE_VERSION" == "" ]]; then # Version is not set
+    GITLAB_IMAGE_VERSION=$(get_latest_version_number_from_dockerhub "$GITLAB_IMAGE_NAME")
+else  # Version is set 
+    AVAILABLE_VERSIONS=$(get_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME")
+    AVAILABLE_VERSIONS=`echo $AVAILABLE_VERSIONS | tr " " "|"`
+    if [[ $GITLAB_IMAGE_VERSION =~ ^($AVAILABLE_VERSIONS) ]]; then
+        true
+    else
+        echo "Gitlab version '$GITLAB_IMAGE_VERSION' is not available!"
+        exit 1
+    fi
 fi
 
-if [ "$(expr "$GITLAB_IMAGE_VERSION" : '^[0-9\.]*-ce\.[0-9]$')" -eq 0 ]; then
-  echo "invalid version pattern '$GITLAB_IMAGE_VERSION', e.g. 13.4.3-ce.0"
+# Classic not supported on DSM6
+if [ "$DSM_VERSION" == "6" ] && [ "$GITLAB_PACKAGE_TYPE" == "classic" ]; then
+  echo "package type '$GITLAB_PACKAGE_TYPE' is not supported for DSM$DSM_VERSION"
   exit 1
 fi
 
-if [ "$GITLAB_DSM_VERSION" == "6" ] && [ "$GITLAB_PACKAGE_TYPE" == "classic" ]; then
-  echo "$GITLAB_PACKAGE_TYPE package type is not supported for dsm$GITLAB_DSM_VERSION"
-  exit 1
-fi
+echo "Building '$GITLAB_IMAGE_VERSION' as '$GITLAB_PACKAGE_TYPE' for DSM$DSM_VERSION..."
 
 ########################################################################################################################
 # PACKAGE BUILD
@@ -168,13 +180,13 @@ GITLAB_IMAGE_VERSION_SHORT=$(echo "$GITLAB_IMAGE_VERSION" | cut -f1 -d-)
 
 # UPDATE INFO FILE
 sed -i -e "/^version=/s/=.*/=\"$GITLAB_IMAGE_VERSION_SHORT\"/" "$DIRECTORY_TMP/INFO"
-sed -i -e "/^os_min_ver=/s/=.*/=\"$GITLAB_DSM_VERSION.0-00000\"/" "$DIRECTORY_TMP/INFO"
+sed -i -e "/^os_min_ver=/s/=.*/=\"$DSM_VERSION.0-00000\"/" "$DIRECTORY_TMP/INFO"
 sed -i -e "/^description=/s/=.*/=\"GitLab CE docker container ($GITLAB_PACKAGE_TYPE)\"/" "$DIRECTORY_TMP/INFO"
 sed -i -e "/^extractsize=/s/=.*/=\"$EXTRACTSIZE\"/" "$DIRECTORY_TMP/INFO"
 
 
 # CREATE FILE
-OUTPUT_FILE_NAME="synology-gitlab-ce-$GITLAB_IMAGE_VERSION_SHORT-dsm$GITLAB_DSM_VERSION-$GITLAB_PACKAGE_TYPE.spk"
+OUTPUT_FILE_NAME="synology-gitlab-ce-$GITLAB_IMAGE_VERSION_SHORT-dsm$DSM_VERSION-$GITLAB_PACKAGE_TYPE.spk"
 cd "$DIRECTORY_TMP/" && tar --format=gnu -cf "../$DIRECTORY_SPK/$OUTPUT_FILE_NAME" * && cd ../
 
 rm -rf "$DIRECTORY_TMP"

--- a/build
+++ b/build
@@ -38,12 +38,15 @@ get_latest_version_number_from_dockerhub() {
   echo "$latest"
 }
 
-get_available_version_numbers_from_dockerhub() {
+show_available_version_numbers_from_dockerhub() {
   local image_name="$1"
 
   versions="$(curl https://hub.docker.com/v2/repositories/"$image_name"/tags 2>/dev/null | jq -r '.results[].name' | grep "\-ce")"
   
-  echo "$versions"
+  echo "Available versions:"
+  while IFS= read -r line; do
+      echo "  - $line"
+  done <<< "$versions"
 }
 
 help()
@@ -88,12 +91,7 @@ do
           GITLAB_DSM_VERSION="${i#*=}"
       ;;
       --list-versions)
-         echo "Available versions:"
-         GITLAB_AVAILABLE_VERSIONS="$(get_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME")"
-         while IFS= read -r line; do
-             echo "  - $line"
-         done <<< "$GITLAB_AVAILABLE_VERSIONS"
-
+         show_available_version_numbers_from_dockerhub "$GITLAB_IMAGE_NAME"
          exit 0
       ;;
       -h|--help)

--- a/build
+++ b/build
@@ -190,4 +190,4 @@ OUTPUT_FILE_NAME="synology-gitlab-ce-$GITLAB_IMAGE_VERSION_SHORT-dsm$DSM_VERSION
 cd "$DIRECTORY_TMP/" && tar --format=gnu -cf "../$DIRECTORY_SPK/$OUTPUT_FILE_NAME" * && cd ../
 
 rm -rf "$DIRECTORY_TMP"
-echo "build complete: $OUTPUT_FILE_NAME"
+echo "build complete: 'spk/$OUTPUT_FILE_NAME'"


### PR DESCRIPTION
Example output:
```
 ./build --list-versions
Available versions:
  - 14.8.4-ce.0
  - 14.8.3-ce.0
  - 14.7.5-ce.0
  - 14.6.6-ce.0
  - 14.6.5-ce.0
  - 14.7.4-ce.0
  - 14.8.2-ce.0
```

I moved it into a separate parameter instead directly into the help to avoid blocking in case the server is not reachable.